### PR TITLE
Python 3.3+ support

### DIFF
--- a/ttp/tests.py
+++ b/ttp/tests.py
@@ -17,6 +17,7 @@
 
 # twp - Unittests --------------------------------------------------------------
 # ------------------------------------------------------------------------------
+from __future__ import unicode_literals
 import unittest
 import ttp
 
@@ -30,538 +31,538 @@ class TWPTests(unittest.TestCase):
     # --------------------------------------------------------------------------
     def test_urls(self):
         """Confirm that # in a URL works along with ,"""
-        result = self.parser.parse(u'big url: http://blah.com:8080/path/to/here?p=1&q=abc,def#posn2 #ahashtag')
-        self.assertEqual(result.urls, [u'http://blah.com:8080/path/to/here?p=1&q=abc,def#posn2'])
-        self.assertEqual(result.tags, [u'ahashtag'])
+        result = self.parser.parse('big url: http://blah.com:8080/path/to/here?p=1&q=abc,def#posn2 #ahashtag')
+        self.assertEqual(result.urls, ['http://blah.com:8080/path/to/here?p=1&q=abc,def#posn2'])
+        self.assertEqual(result.tags, ['ahashtag'])
 
     def test_all_not_allow_amp_without_question(self):
-        result = self.parser.parse(u'Check out: http://www.github.com/test&@username')
-        self.assertEqual(result.html, u'Check out: <a href="http://www.github.com/test">http://www.github.com/test</a>&<a href="https://twitter.com/username">@username</a>')
-        self.assertEqual(result.users, [u'username'])
-        self.assertEqual(result.urls, [u'http://www.github.com/test'])
+        result = self.parser.parse('Check out: http://www.github.com/test&@username')
+        self.assertEqual(result.html, 'Check out: <a href="http://www.github.com/test">http://www.github.com/test</a>&<a href="https://twitter.com/username">@username</a>')
+        self.assertEqual(result.users, ['username'])
+        self.assertEqual(result.urls, ['http://www.github.com/test'])
 
     def test_all_not_break_url_at(self):
-        result = self.parser.parse(u'http://www.flickr.com/photos/29674651@N00/4382024406')
-        self.assertEqual(result.html, u'<a href="http://www.flickr.com/photos/29674651@N00/4382024406">http://www.flickr.com/photo...</a>')
-        self.assertEqual(result.urls, [u'http://www.flickr.com/photos/29674651@N00/4382024406'])
+        result = self.parser.parse('http://www.flickr.com/photos/29674651@N00/4382024406')
+        self.assertEqual(result.html, '<a href="http://www.flickr.com/photos/29674651@N00/4382024406">http://www.flickr.com/photo...</a>')
+        self.assertEqual(result.urls, ['http://www.flickr.com/photos/29674651@N00/4382024406'])
 
     # URL tests ----------------------------------------------------------------
     # --------------------------------------------------------------------------
     def test_url_mid(self):
-        result = self.parser.parse(u'text http://example.com more text')
-        self.assertEqual(result.html, u'text <a href="http://example.com">http://example.com</a> more text')
-        self.assertEqual(result.urls, [u'http://example.com'])
+        result = self.parser.parse('text http://example.com more text')
+        self.assertEqual(result.html, 'text <a href="http://example.com">http://example.com</a> more text')
+        self.assertEqual(result.urls, ['http://example.com'])
 
     def test_url_unicode(self):
-        result = self.parser.parse(u'I enjoy Macintosh Brand computers: http://✪df.ws/ejp')
-        self.assertEqual(result.html, u'I enjoy Macintosh Brand computers: <a href="http://✪df.ws/ejp">http://✪df.ws/ejp</a>')
-        self.assertEqual(result.urls, [u'http://\u272adf.ws/ejp'])
+        result = self.parser.parse('I enjoy Macintosh Brand computers: http://✪df.ws/ejp')
+        self.assertEqual(result.html, 'I enjoy Macintosh Brand computers: <a href="http://✪df.ws/ejp">http://✪df.ws/ejp</a>')
+        self.assertEqual(result.urls, ['http://\u272adf.ws/ejp'])
 
     def test_url_parentheses(self):
-        result = self.parser.parse(u'text (http://example.com)')
-        self.assertEqual(result.html, u'text (<a href="http://example.com">http://example.com</a>)')
-        self.assertEqual(result.urls, [u'http://example.com'])
+        result = self.parser.parse('text (http://example.com)')
+        self.assertEqual(result.html, 'text (<a href="http://example.com">http://example.com</a>)')
+        self.assertEqual(result.urls, ['http://example.com'])
 
     def test_url_underscore(self):
-        result = self.parser.parse(u'text http://example.com/test/foo_123.jpg')
-        self.assertEqual(result.html, u'text <a href="http://example.com/test/foo_123.jpg">http://example.com/test/foo...</a>')
-        self.assertEqual(result.urls, [u'http://example.com/test/foo_123.jpg'])
+        result = self.parser.parse('text http://example.com/test/foo_123.jpg')
+        self.assertEqual(result.html, 'text <a href="http://example.com/test/foo_123.jpg">http://example.com/test/foo...</a>')
+        self.assertEqual(result.urls, ['http://example.com/test/foo_123.jpg'])
 
     def test_url_underscore_dot(self):
-        result = self.parser.parse(u'text http://example.com/test/bla.net_foo_123.jpg')
-        self.assertEqual(result.html, u'text <a href="http://example.com/test/bla.net_foo_123.jpg">http://example.com/test/bla...</a>')
-        self.assertEqual(result.urls, [u'http://example.com/test/bla.net_foo_123.jpg'])
+        result = self.parser.parse('text http://example.com/test/bla.net_foo_123.jpg')
+        self.assertEqual(result.html, 'text <a href="http://example.com/test/bla.net_foo_123.jpg">http://example.com/test/bla...</a>')
+        self.assertEqual(result.urls, ['http://example.com/test/bla.net_foo_123.jpg'])
 
     def test_url_amp_lang_equals(self):
-        result = self.parser.parse(u'Check out https://twitter.com/search?q=avro&lang=en')
-        self.assertEqual(result.html, u'Check out <a href="https://twitter.com/search?q=avro&amp;lang=en">https://twitter.com/search?...</a>')
-        self.assertEqual(result.urls, [u'https://twitter.com/search?q=avro&lang=en'])
+        result = self.parser.parse('Check out https://twitter.com/search?q=avro&lang=en')
+        self.assertEqual(result.html, 'Check out <a href="https://twitter.com/search?q=avro&amp;lang=en">https://twitter.com/search?...</a>')
+        self.assertEqual(result.urls, ['https://twitter.com/search?q=avro&lang=en'])
 
     def test_url_amp_break(self):
-        result = self.parser.parse(u'Check out http://twitter.com/te?foo&invalid=True')
-        self.assertEqual(result.html, u'Check out <a href="http://twitter.com/te?foo&amp;invalid=True">http://twitter.com/te?foo...</a>')
-        self.assertEqual(result.urls, [u'http://twitter.com/te?foo&invalid=True'])
+        result = self.parser.parse('Check out http://twitter.com/te?foo&invalid=True')
+        self.assertEqual(result.html, 'Check out <a href="http://twitter.com/te?foo&amp;invalid=True">http://twitter.com/te?foo...</a>')
+        self.assertEqual(result.urls, ['http://twitter.com/te?foo&invalid=True'])
 
     def test_url_dash(self):
-        result = self.parser.parse(u'Is www.foo-bar.com a valid URL?')
-        self.assertEqual(result.html, u'Is <a href="https://www.foo-bar.com">www.foo-bar.com</a> a valid URL?')
-        self.assertEqual(result.urls, [u'www.foo-bar.com'])
+        result = self.parser.parse('Is www.foo-bar.com a valid URL?')
+        self.assertEqual(result.html, 'Is <a href="https://www.foo-bar.com">www.foo-bar.com</a> a valid URL?')
+        self.assertEqual(result.urls, ['www.foo-bar.com'])
 
     def test_url_multiple(self):
-        result = self.parser.parse(u'http://example.com https://sslexample.com http://sub.example.com')
+        result = self.parser.parse('http://example.com https://sslexample.com http://sub.example.com')
         self.assertEqual(
-            result.html, u'<a href="http://example.com">http://example.com</a> <a href="https://sslexample.com">https://sslexample.com</a> <a href="http://sub.example.com">http://sub.example.com</a>')
-        self.assertEqual(result.urls, [u'http://example.com', u'https://sslexample.com', u'http://sub.example.com'])
+            result.html, '<a href="http://example.com">http://example.com</a> <a href="https://sslexample.com">https://sslexample.com</a> <a href="http://sub.example.com">http://sub.example.com</a>')
+        self.assertEqual(result.urls, ['http://example.com', 'https://sslexample.com', 'http://sub.example.com'])
 
     def test_url_raw_domain(self):
-        result = self.parser.parse(u'See http://example.com example.com')
-        self.assertEqual(result.html, u'See <a href="http://example.com">http://example.com</a> example.com')
-        self.assertEqual(result.urls, [u'http://example.com'])
+        result = self.parser.parse('See http://example.com example.com')
+        self.assertEqual(result.html, 'See <a href="http://example.com">http://example.com</a> example.com')
+        self.assertEqual(result.urls, ['http://example.com'])
 
     def test_url_embed_link(self):
-        result = self.parser.parse(u'<link rel=\'true\'>http://example.com</link>')
-        self.assertEqual(result.html, u'<link rel=\'true\'><a href="http://example.com">http://example.com</a></link>')
-        self.assertEqual(result.urls, [u'http://example.com'])
+        result = self.parser.parse('<link rel=\'true\'>http://example.com</link>')
+        self.assertEqual(result.html, '<link rel=\'true\'><a href="http://example.com">http://example.com</a></link>')
+        self.assertEqual(result.urls, ['http://example.com'])
 
     def test_url_trailing(self):
-        result = self.parser.parse(u'text http://example.com')
-        self.assertEqual(result.html, u'text <a href="http://example.com">http://example.com</a>')
-        self.assertEqual(result.urls, [u'http://example.com'])
+        result = self.parser.parse('text http://example.com')
+        self.assertEqual(result.html, 'text <a href="http://example.com">http://example.com</a>')
+        self.assertEqual(result.urls, ['http://example.com'])
 
     def test_url_japanese(self):
-        result = self.parser.parse(u'いまなにしてるhttp://example.comいまなにしてる')
-        self.assertEqual(result.html, u'いまなにしてる<a href="http://example.com">http://example.com</a>いまなにしてる')
-        self.assertEqual(result.urls, [u'http://example.com'])
+        result = self.parser.parse('いまなにしてるhttp://example.comいまなにしてる')
+        self.assertEqual(result.html, 'いまなにしてる<a href="http://example.com">http://example.com</a>いまなにしてる')
+        self.assertEqual(result.urls, ['http://example.com'])
 
     def test_url_lots_of_punctuation(self):
-        result = self.parser.parse(u'text http://xo.com/~matthew+%-,.;x')
-        self.assertEqual(result.html, u'text <a href="http://xo.com/~matthew+%-,.;x">http://xo.com/~matthew+%-,.;x</a>')
-        self.assertEqual(result.urls, [u'http://xo.com/~matthew+%-,.;x'])
+        result = self.parser.parse('text http://xo.com/~matthew+%-,.;x')
+        self.assertEqual(result.html, 'text <a href="http://xo.com/~matthew+%-,.;x">http://xo.com/~matthew+%-,.;x</a>')
+        self.assertEqual(result.urls, ['http://xo.com/~matthew+%-,.;x'])
 
     def test_url_question_numbers(self):
-        result = self.parser.parse(u'text http://example.com/?77e8fd')
-        self.assertEqual(result.html, u'text <a href="http://example.com/?77e8fd">http://example.com/?77e8fd</a>')
-        self.assertEqual(result.urls, [u'http://example.com/?77e8fd'])
+        result = self.parser.parse('text http://example.com/?77e8fd')
+        self.assertEqual(result.html, 'text <a href="http://example.com/?77e8fd">http://example.com/?77e8fd</a>')
+        self.assertEqual(result.urls, ['http://example.com/?77e8fd'])
 
     def test_url_one_letter_other(self):
-        result = self.parser.parse(u'text http://u.nu/')
-        self.assertEqual(result.html, u'text <a href="http://u.nu/">http://u.nu/</a>')
-        self.assertEqual(result.urls, [u'http://u.nu/'])
+        result = self.parser.parse('text http://u.nu/')
+        self.assertEqual(result.html, 'text <a href="http://u.nu/">http://u.nu/</a>')
+        self.assertEqual(result.urls, ['http://u.nu/'])
 
-        result = self.parser.parse(u'text http://u.tv/')
-        self.assertEqual(result.html, u'text <a href="http://u.tv/">http://u.tv/</a>')
-        self.assertEqual(result.urls, [u'http://u.tv/'])
+        result = self.parser.parse('text http://u.tv/')
+        self.assertEqual(result.html, 'text <a href="http://u.tv/">http://u.tv/</a>')
+        self.assertEqual(result.urls, ['http://u.tv/'])
 
     def test_url_one_letter_iana(self):
-        result = self.parser.parse(u'text http://x.com/')
-        self.assertEqual(result.html, u'text <a href="http://x.com/">http://x.com/</a>')
-        self.assertEqual(result.urls, [u'http://x.com/'])
+        result = self.parser.parse('text http://x.com/')
+        self.assertEqual(result.html, 'text <a href="http://x.com/">http://x.com/</a>')
+        self.assertEqual(result.urls, ['http://x.com/'])
 
-        result = self.parser.parse(u'text http://Q.com/')
-        self.assertEqual(result.html, u'text <a href="http://Q.com/">http://Q.com/</a>')
-        self.assertEqual(result.urls, [u'http://Q.com/'])
+        result = self.parser.parse('text http://Q.com/')
+        self.assertEqual(result.html, 'text <a href="http://Q.com/">http://Q.com/</a>')
+        self.assertEqual(result.urls, ['http://Q.com/'])
 
-        result = self.parser.parse(u'text http://z.com/')
-        self.assertEqual(result.html, u'text <a href="http://z.com/">http://z.com/</a>')
-        self.assertEqual(result.urls, [u'http://z.com/'])
+        result = self.parser.parse('text http://z.com/')
+        self.assertEqual(result.html, 'text <a href="http://z.com/">http://z.com/</a>')
+        self.assertEqual(result.urls, ['http://z.com/'])
 
-        result = self.parser.parse(u'text http://i.net/')
-        self.assertEqual(result.html, u'text <a href="http://i.net/">http://i.net/</a>')
-        self.assertEqual(result.urls, [u'http://i.net/'])
+        result = self.parser.parse('text http://i.net/')
+        self.assertEqual(result.html, 'text <a href="http://i.net/">http://i.net/</a>')
+        self.assertEqual(result.urls, ['http://i.net/'])
 
-        result = self.parser.parse(u'text http://q.net/')
-        self.assertEqual(result.html, u'text <a href="http://q.net/">http://q.net/</a>')
-        self.assertEqual(result.urls, [u'http://q.net/'])
+        result = self.parser.parse('text http://q.net/')
+        self.assertEqual(result.html, 'text <a href="http://q.net/">http://q.net/</a>')
+        self.assertEqual(result.urls, ['http://q.net/'])
 
-        result = self.parser.parse(u'text http://X.org/')
-        self.assertEqual(result.html, u'text <a href="http://X.org/">http://X.org/</a>')
-        self.assertEqual(result.urls, [u'http://X.org/'])
+        result = self.parser.parse('text http://X.org/')
+        self.assertEqual(result.html, 'text <a href="http://X.org/">http://X.org/</a>')
+        self.assertEqual(result.urls, ['http://X.org/'])
 
     def test_url_long_hypens(self):
-        result = self.parser.parse(u'text http://word-and-a-number-8-ftw.domain.tld/')
-        self.assertEqual(result.html, u'text <a href="http://word-and-a-number-8-ftw.domain.tld/">http://word-and-a-number-8-...</a>')
-        self.assertEqual(result.urls, [u'http://word-and-a-number-8-ftw.domain.tld/'])
+        result = self.parser.parse('text http://word-and-a-number-8-ftw.domain.tld/')
+        self.assertEqual(result.html, 'text <a href="http://word-and-a-number-8-ftw.domain.tld/">http://word-and-a-number-8-...</a>')
+        self.assertEqual(result.urls, ['http://word-and-a-number-8-ftw.domain.tld/'])
 
     # URL not tests ------------------------------------------------------------
     def test_not_url_dotdotdot(self):
-        result = self.parser.parse(u'Is www...foo a valid URL?')
-        self.assertEqual(result.html, u'Is www...foo a valid URL?')
+        result = self.parser.parse('Is www...foo a valid URL?')
+        self.assertEqual(result.html, 'Is www...foo a valid URL?')
         self.assertEqual(result.urls, [])
 
     def test_not_url_dash(self):
-        result = self.parser.parse(u'Is www.-foo.com a valid URL?')
-        self.assertEqual(result.html, u'Is www.-foo.com a valid URL?')
+        result = self.parser.parse('Is www.-foo.com a valid URL?')
+        self.assertEqual(result.html, 'Is www.-foo.com a valid URL?')
         self.assertEqual(result.urls, [])
 
     def test_not_url_no_tld(self):
-        result = self.parser.parse(u'Is http://no-tld a valid URL?')
-        self.assertEqual(result.html, u'Is http://no-tld a valid URL?')
+        result = self.parser.parse('Is http://no-tld a valid URL?')
+        self.assertEqual(result.html, 'Is http://no-tld a valid URL?')
         self.assertEqual(result.urls, [])
 
     def test_not_url_tld_too_short(self):
-        result = self.parser.parse(u'Is http://tld-too-short.x a valid URL?')
-        self.assertEqual(result.html, u'Is http://tld-too-short.x a valid URL?')
+        result = self.parser.parse('Is http://tld-too-short.x a valid URL?')
+        self.assertEqual(result.html, 'Is http://tld-too-short.x a valid URL?')
         self.assertEqual(result.urls, [])
 
     def test_all_not_break_url_at2(self):
-        result = self.parser.parse(u'http://www.flickr.com/photos/29674651@N00/4382024406')
-        self.assertEqual(result.html, u'<a href="http://www.flickr.com/photos/29674651@N00/4382024406">http://www.flickr.com/photo...</a>')
-        self.assertEqual(result.urls, [u'http://www.flickr.com/photos/29674651@N00/4382024406'])
+        result = self.parser.parse('http://www.flickr.com/photos/29674651@N00/4382024406')
+        self.assertEqual(result.html, '<a href="http://www.flickr.com/photos/29674651@N00/4382024406">http://www.flickr.com/photo...</a>')
+        self.assertEqual(result.urls, ['http://www.flickr.com/photos/29674651@N00/4382024406'])
 
     def test_not_url_one_letter_iana(self):
-        result = self.parser.parse(u'text http://a.com/ http://a.net/ http://a.org/')
-        self.assertEqual(result.html, u'text http://a.com/ http://a.net/ http://a.org/')
+        result = self.parser.parse('text http://a.com/ http://a.net/ http://a.org/')
+        self.assertEqual(result.html, 'text http://a.com/ http://a.net/ http://a.org/')
         self.assertEqual(result.urls, [])
 
     # URL followed Tests -------------------------------------------------------
     def test_url_followed_question(self):
-        result = self.parser.parse(u'text http://example.com?')
-        self.assertEqual(result.html, u'text <a href="http://example.com">http://example.com</a>?')
-        self.assertEqual(result.urls, [u'http://example.com'])
+        result = self.parser.parse('text http://example.com?')
+        self.assertEqual(result.html, 'text <a href="http://example.com">http://example.com</a>?')
+        self.assertEqual(result.urls, ['http://example.com'])
 
     def test_url_followed_colon(self):
-        result = self.parser.parse(u'text http://example.com:')
-        self.assertEqual(result.html, u'text <a href="http://example.com">http://example.com</a>:')
-        self.assertEqual(result.urls, [u'http://example.com'])
+        result = self.parser.parse('text http://example.com:')
+        self.assertEqual(result.html, 'text <a href="http://example.com">http://example.com</a>:')
+        self.assertEqual(result.urls, ['http://example.com'])
 
     def test_url_followed_curly_brace(self):
-        result = self.parser.parse(u'text http://example.com}')
-        self.assertEqual(result.html, u'text <a href="http://example.com">http://example.com</a>}')
-        self.assertEqual(result.urls, [u'http://example.com'])
+        result = self.parser.parse('text http://example.com}')
+        self.assertEqual(result.html, 'text <a href="http://example.com">http://example.com</a>}')
+        self.assertEqual(result.urls, ['http://example.com'])
 
     def test_url_followed_single_quote(self):
-        result = self.parser.parse(u'text http://example.com')
-        self.assertEqual(result.html, u'text <a href="http://example.com">http://example.com</a>')
-        self.assertEqual(result.urls, [u'http://example.com'])
+        result = self.parser.parse('text http://example.com')
+        self.assertEqual(result.html, 'text <a href="http://example.com">http://example.com</a>')
+        self.assertEqual(result.urls, ['http://example.com'])
 
     def test_url_followed_dot(self):
-        result = self.parser.parse(u'text http://example.com.')
-        self.assertEqual(result.html, u'text <a href="http://example.com">http://example.com</a>.')
-        self.assertEqual(result.urls, [u'http://example.com'])
+        result = self.parser.parse('text http://example.com.')
+        self.assertEqual(result.html, 'text <a href="http://example.com">http://example.com</a>.')
+        self.assertEqual(result.urls, ['http://example.com'])
 
     def test_url_followed_exclamation(self):
-        result = self.parser.parse(u'text http://example.com!')
-        self.assertEqual(result.html, u'text <a href="http://example.com">http://example.com</a>!')
-        self.assertEqual(result.urls, [u'http://example.com'])
+        result = self.parser.parse('text http://example.com!')
+        self.assertEqual(result.html, 'text <a href="http://example.com">http://example.com</a>!')
+        self.assertEqual(result.urls, ['http://example.com'])
 
     def test_url_followed_comma(self):
-        result = self.parser.parse(u'text http://example.com,')
-        self.assertEqual(result.html, u'text <a href="http://example.com">http://example.com</a>,')
-        self.assertEqual(result.urls, [u'http://example.com'])
+        result = self.parser.parse('text http://example.com,')
+        self.assertEqual(result.html, 'text <a href="http://example.com">http://example.com</a>,')
+        self.assertEqual(result.urls, ['http://example.com'])
 
     def test_url_with_path_preceeded_by_comma(self):
-        result = self.parser.parse(u'text ,http://example.com/abcde, more')
-        self.assertEqual(result.html, u'text ,<a href="http://example.com/abcde">http://example.com/abcde</a>, more')
-        self.assertEqual(result.urls, [u'http://example.com/abcde'])
+        result = self.parser.parse('text ,http://example.com/abcde, more')
+        self.assertEqual(result.html, 'text ,<a href="http://example.com/abcde">http://example.com/abcde</a>, more')
+        self.assertEqual(result.urls, ['http://example.com/abcde'])
 
     def test_url_with_path_followed_comma(self):
-        result = self.parser.parse(u'text http://example.com/abcde, more')
-        self.assertEqual(result.html, u'text <a href="http://example.com/abcde">http://example.com/abcde</a>, more')
-        self.assertEqual(result.urls, [u'http://example.com/abcde'])
+        result = self.parser.parse('text http://example.com/abcde, more')
+        self.assertEqual(result.html, 'text <a href="http://example.com/abcde">http://example.com/abcde</a>, more')
+        self.assertEqual(result.urls, ['http://example.com/abcde'])
 
     def test_url_with_path_followed_commas(self):
-        result = self.parser.parse(u'text http://example.com/abcde,, more')
-        self.assertEqual(result.html, u'text <a href="http://example.com/abcde">http://example.com/abcde</a>,, more')
-        self.assertEqual(result.urls, [u'http://example.com/abcde'])
+        result = self.parser.parse('text http://example.com/abcde,, more')
+        self.assertEqual(result.html, 'text <a href="http://example.com/abcde">http://example.com/abcde</a>,, more')
+        self.assertEqual(result.urls, ['http://example.com/abcde'])
 
     def test_url_followed_brace(self):
-        result = self.parser.parse(u'text http://example.com)')
-        self.assertEqual(result.html, u'text <a href="http://example.com">http://example.com</a>)')
-        self.assertEqual(result.urls, [u'http://example.com'])
+        result = self.parser.parse('text http://example.com)')
+        self.assertEqual(result.html, 'text <a href="http://example.com">http://example.com</a>)')
+        self.assertEqual(result.urls, ['http://example.com'])
 
     def test_url_followed_big_brace(self):
-        result = self.parser.parse(u'text http://example.com]')
-        self.assertEqual(result.html, u'text <a href="http://example.com">http://example.com</a>]')
-        self.assertEqual(result.urls, [u'http://example.com'])
+        result = self.parser.parse('text http://example.com]')
+        self.assertEqual(result.html, 'text <a href="http://example.com">http://example.com</a>]')
+        self.assertEqual(result.urls, ['http://example.com'])
 
     def test_url_followed_equals(self):
-        result = self.parser.parse(u'text http://example.com=')
-        self.assertEqual(result.html, u'text <a href="http://example.com">http://example.com</a>=')
-        self.assertEqual(result.urls, [u'http://example.com'])
+        result = self.parser.parse('text http://example.com=')
+        self.assertEqual(result.html, 'text <a href="http://example.com">http://example.com</a>=')
+        self.assertEqual(result.urls, ['http://example.com'])
 
     def test_url_followed_semicolon(self):
-        result = self.parser.parse(u'text http://example.com;')
-        self.assertEqual(result.html, u'text <a href="http://example.com">http://example.com</a>;')
-        self.assertEqual(result.urls, [u'http://example.com'])
+        result = self.parser.parse('text http://example.com;')
+        self.assertEqual(result.html, 'text <a href="http://example.com">http://example.com</a>;')
+        self.assertEqual(result.urls, ['http://example.com'])
 
     def test_url_followed_hypen(self):
-        result = self.parser.parse(u'text http://domain.tld-that-you-should-have-put-a-space-after')
-        self.assertEqual(result.html, u'text <a href="http://domain.tld">http://domain.tld</a>-that-you-should-have-put-a-space-after')
-        self.assertEqual(result.urls, [u'http://domain.tld'])
+        result = self.parser.parse('text http://domain.tld-that-you-should-have-put-a-space-after')
+        self.assertEqual(result.html, 'text <a href="http://domain.tld">http://domain.tld</a>-that-you-should-have-put-a-space-after')
+        self.assertEqual(result.urls, ['http://domain.tld'])
 
     # URL preceeded Tests -------------------------------------------------------
     def test_url_preceeded_colon(self):
-        result = self.parser.parse(u'text:http://example.com')
-        self.assertEqual(result.html, u'text:<a href="http://example.com">http://example.com</a>')
-        self.assertEqual(result.urls, [u'http://example.com'])
+        result = self.parser.parse('text:http://example.com')
+        self.assertEqual(result.html, 'text:<a href="http://example.com">http://example.com</a>')
+        self.assertEqual(result.urls, ['http://example.com'])
 
     def test_not_url_preceeded_equals(self):
-        result = self.parser.parse(u'text =http://example.com')
-        self.assertEqual(result.html, u'text =http://example.com')
+        result = self.parser.parse('text =http://example.com')
+        self.assertEqual(result.html, 'text =http://example.com')
         self.assertEqual(result.urls, [])
 
     # NOT
     def test_not_url_preceeded_forwardslash(self):
-        result = self.parser.parse(u'text /http://example.com')
-        self.assertEqual(result.html, u'text /http://example.com')
+        result = self.parser.parse('text /http://example.com')
+        self.assertEqual(result.html, 'text /http://example.com')
         self.assertEqual(result.urls, [])
 
     def test_not_url_preceeded_exclamation(self):
-        result = self.parser.parse(u'text !http://example.com')
-        self.assertEqual(result.html, u'text !http://example.com')
+        result = self.parser.parse('text !http://example.com')
+        self.assertEqual(result.html, 'text !http://example.com')
         self.assertEqual(result.urls, [])
 
     # URL numeric tests --------------------------------------------------------
     def test_url_at_numeric(self):
-        result = self.parser.parse(u'http://www.flickr.com/photos/29674651@N00/4382024406')
-        self.assertEqual(result.html, u'<a href="http://www.flickr.com/photos/29674651@N00/4382024406">http://www.flickr.com/photo...</a>')
-        self.assertEqual(result.urls, [u'http://www.flickr.com/photos/29674651@N00/4382024406'])
+        result = self.parser.parse('http://www.flickr.com/photos/29674651@N00/4382024406')
+        self.assertEqual(result.html, '<a href="http://www.flickr.com/photos/29674651@N00/4382024406">http://www.flickr.com/photo...</a>')
+        self.assertEqual(result.urls, ['http://www.flickr.com/photos/29674651@N00/4382024406'])
 
     def test_url_at_non_numeric(self):
-        result = self.parser.parse(u'http://www.flickr.com/photos/29674651@N00/foobar')
-        self.assertEqual(result.html, u'<a href="http://www.flickr.com/photos/29674651@N00/foobar">http://www.flickr.com/photo...</a>')
-        self.assertEqual(result.urls, [u'http://www.flickr.com/photos/29674651@N00/foobar'])
+        result = self.parser.parse('http://www.flickr.com/photos/29674651@N00/foobar')
+        self.assertEqual(result.html, '<a href="http://www.flickr.com/photos/29674651@N00/foobar">http://www.flickr.com/photo...</a>')
+        self.assertEqual(result.urls, ['http://www.flickr.com/photos/29674651@N00/foobar'])
 
     # URL domain tests ---------------------------------------------------------
     def test_url_WWW(self):
-        result = self.parser.parse(u'WWW.EXAMPLE.COM')
-        self.assertEqual(result.html, u'<a href="https://WWW.EXAMPLE.COM">WWW.EXAMPLE.COM</a>')
-        self.assertEqual(result.urls, [u'WWW.EXAMPLE.COM'])
+        result = self.parser.parse('WWW.EXAMPLE.COM')
+        self.assertEqual(result.html, '<a href="https://WWW.EXAMPLE.COM">WWW.EXAMPLE.COM</a>')
+        self.assertEqual(result.urls, ['WWW.EXAMPLE.COM'])
 
     def test_url_www(self):
-        result = self.parser.parse(u'www.example.com')
-        self.assertEqual(result.html, u'<a href="https://www.example.com">www.example.com</a>')
-        self.assertEqual(result.urls, [u'www.example.com'])
+        result = self.parser.parse('www.example.com')
+        self.assertEqual(result.html, '<a href="https://www.example.com">www.example.com</a>')
+        self.assertEqual(result.urls, ['www.example.com'])
 
     def test_url_only_domain_query_followed_period(self):
-        result = self.parser.parse(u'I think it\'s proper to end sentences with a period http://tell.me/why?=because.i.want.it. Even when they contain a URL.')
+        result = self.parser.parse('I think it\'s proper to end sentences with a period http://tell.me/why?=because.i.want.it. Even when they contain a URL.')
         self.assertEqual(
-            result.html, u'I think it\'s proper to end sentences with a period <a href="http://tell.me/why?=because.i.want.it">http://tell.me/why?=because...</a>. Even when they contain a URL.')
-        self.assertEqual(result.urls, [u'http://tell.me/why?=because.i.want.it'])
+            result.html, 'I think it\'s proper to end sentences with a period <a href="http://tell.me/why?=because.i.want.it">http://tell.me/why?=because...</a>. Even when they contain a URL.')
+        self.assertEqual(result.urls, ['http://tell.me/why?=because.i.want.it'])
 
     def test_url_only_domain_followed_period(self):
-        result = self.parser.parse(u'I think it\'s proper to end sentences with a period http://tell.me. Even when they contain a URL.')
-        self.assertEqual(result.html, u'I think it\'s proper to end sentences with a period <a href="http://tell.me">http://tell.me</a>. Even when they contain a URL.')
-        self.assertEqual(result.urls, [u'http://tell.me'])
+        result = self.parser.parse('I think it\'s proper to end sentences with a period http://tell.me. Even when they contain a URL.')
+        self.assertEqual(result.html, 'I think it\'s proper to end sentences with a period <a href="http://tell.me">http://tell.me</a>. Even when they contain a URL.')
+        self.assertEqual(result.urls, ['http://tell.me'])
 
     def test_url_only_domain_path_followed_period(self):
-        result = self.parser.parse(u'I think it\'s proper to end sentences with a period http://tell.me/why. Even when they contain a URL.')
-        self.assertEqual(result.html, u'I think it\'s proper to end sentences with a period <a href="http://tell.me/why">http://tell.me/why</a>. Even when they contain a URL.')
-        self.assertEqual(result.urls, [u'http://tell.me/why'])
+        result = self.parser.parse('I think it\'s proper to end sentences with a period http://tell.me/why. Even when they contain a URL.')
+        self.assertEqual(result.html, 'I think it\'s proper to end sentences with a period <a href="http://tell.me/why">http://tell.me/why</a>. Even when they contain a URL.')
+        self.assertEqual(result.urls, ['http://tell.me/why'])
 
     def test_url_long_tld(self):
-        result = self.parser.parse(u'http://example.mobi/path')
-        self.assertEqual(result.html, u'<a href="http://example.mobi/path">http://example.mobi/path</a>')
-        self.assertEqual(result.urls, [u'http://example.mobi/path'])
+        result = self.parser.parse('http://example.mobi/path')
+        self.assertEqual(result.html, '<a href="http://example.mobi/path">http://example.mobi/path</a>')
+        self.assertEqual(result.urls, ['http://example.mobi/path'])
 
     def test_url_multiple_protocols(self):
-        result = self.parser.parse(u'http://foo.com AND https://bar.com AND www.foobar.com')
-        self.assertEqual(result.html, u'<a href="http://foo.com">http://foo.com</a> AND <a href="https://bar.com">https://bar.com</a> AND <a href="https://www.foobar.com">www.foobar.com</a>')
-        self.assertEqual(result.urls, [u'http://foo.com', u'https://bar.com', u'www.foobar.com'])
+        result = self.parser.parse('http://foo.com AND https://bar.com AND www.foobar.com')
+        self.assertEqual(result.html, '<a href="http://foo.com">http://foo.com</a> AND <a href="https://bar.com">https://bar.com</a> AND <a href="https://www.foobar.com">www.foobar.com</a>')
+        self.assertEqual(result.urls, ['http://foo.com', 'https://bar.com', 'www.foobar.com'])
 
     # NOT
     def test_not_url_exclamation_domain(self):
-        result = self.parser.parse(u'badly formatted http://foo!bar.com')
-        self.assertEqual(result.html, u'badly formatted http://foo!bar.com')
+        result = self.parser.parse('badly formatted http://foo!bar.com')
+        self.assertEqual(result.html, 'badly formatted http://foo!bar.com')
         self.assertEqual(result.urls, [])
 
     def test_not_url_under_domain(self):
-        result = self.parser.parse(u'badly formatted http://foo_bar.com')
-        self.assertEqual(result.html, u'badly formatted http://foo_bar.com')
+        result = self.parser.parse('badly formatted http://foo_bar.com')
+        self.assertEqual(result.html, 'badly formatted http://foo_bar.com')
         self.assertEqual(result.urls, [])
 
     # Hashtag tests ------------------------------------------------------------
     # --------------------------------------------------------------------------
     def test_hashtag_followed_full_whitespace(self):
-        result = self.parser.parse(u'#hashtag　text')
-        self.assertEqual(result.html, u'<a href="https://twitter.com/search?q=%23hashtag">#hashtag</a>　text')
-        self.assertEqual(result.tags, [u'hashtag'])
+        result = self.parser.parse('#hashtag　text')
+        self.assertEqual(result.html, '<a href="https://twitter.com/search?q=%23hashtag">#hashtag</a>　text')
+        self.assertEqual(result.tags, ['hashtag'])
 
     def test_hashtag_followed_full_hash(self):
-        result = self.parser.parse(u'＃hashtag')
-        self.assertEqual(result.html, u'<a href="https://twitter.com/search?q=%23hashtag">＃hashtag</a>')
-        self.assertEqual(result.tags, [u'hashtag'])
+        result = self.parser.parse('＃hashtag')
+        self.assertEqual(result.html, '<a href="https://twitter.com/search?q=%23hashtag">＃hashtag</a>')
+        self.assertEqual(result.tags, ['hashtag'])
 
     def test_hashtag_preceeded_full_whitespace(self):
-        result = self.parser.parse(u'text　#hashtag')
-        self.assertEqual(result.html, u'text　<a href="https://twitter.com/search?q=%23hashtag">#hashtag</a>')
-        self.assertEqual(result.tags, [u'hashtag'])
+        result = self.parser.parse('text　#hashtag')
+        self.assertEqual(result.html, 'text　<a href="https://twitter.com/search?q=%23hashtag">#hashtag</a>')
+        self.assertEqual(result.tags, ['hashtag'])
 
     def test_hashtag_number(self):
-        result = self.parser.parse(u'text #1tag')
-        self.assertEqual(result.html, u'text <a href="https://twitter.com/search?q=%231tag">#1tag</a>')
-        self.assertEqual(result.tags, [u'1tag'])
+        result = self.parser.parse('text #1tag')
+        self.assertEqual(result.html, 'text <a href="https://twitter.com/search?q=%231tag">#1tag</a>')
+        self.assertEqual(result.tags, ['1tag'])
 
     def test_not_hashtag_escape(self):
-        result = self.parser.parse(u'&#nbsp;')
-        self.assertEqual(result.html, u'&#nbsp;')
+        result = self.parser.parse('&#nbsp;')
+        self.assertEqual(result.html, '&#nbsp;')
         self.assertEqual(result.tags, [])
 
     def test_hashtag_japanese(self):
-        result = self.parser.parse(u'text #hashtagの')
-        self.assertEqual(result.html, u'text <a href="https://twitter.com/search?q=%23hashtag">#hashtag</a>の')
-        self.assertEqual(result.tags, [u'hashtag'])
+        result = self.parser.parse('text #hashtagの')
+        self.assertEqual(result.html, 'text <a href="https://twitter.com/search?q=%23hashtag">#hashtag</a>の')
+        self.assertEqual(result.tags, ['hashtag'])
 
     def test_hashtag_period(self):
-        result = self.parser.parse(u'text.#hashtag')
-        self.assertEqual(result.html, u'text.<a href="https://twitter.com/search?q=%23hashtag">#hashtag</a>')
-        self.assertEqual(result.tags, [u'hashtag'])
+        result = self.parser.parse('text.#hashtag')
+        self.assertEqual(result.html, 'text.<a href="https://twitter.com/search?q=%23hashtag">#hashtag</a>')
+        self.assertEqual(result.tags, ['hashtag'])
 
     def test_hashtag_trailing(self):
-        result = self.parser.parse(u'text #hashtag')
-        self.assertEqual(result.html, u'text <a href="https://twitter.com/search?q=%23hashtag">#hashtag</a>')
-        self.assertEqual(result.tags, [u'hashtag'])
+        result = self.parser.parse('text #hashtag')
+        self.assertEqual(result.html, 'text <a href="https://twitter.com/search?q=%23hashtag">#hashtag</a>')
+        self.assertEqual(result.tags, ['hashtag'])
 
     def test_not_hashtag_exclamation(self):
-        result = self.parser.parse(u'text #hashtag!')
-        self.assertEqual(result.html, u'text <a href="https://twitter.com/search?q=%23hashtag">#hashtag</a>!')
-        self.assertEqual(result.tags, [u'hashtag'])
+        result = self.parser.parse('text #hashtag!')
+        self.assertEqual(result.html, 'text <a href="https://twitter.com/search?q=%23hashtag">#hashtag</a>!')
+        self.assertEqual(result.tags, ['hashtag'])
 
     def test_hashtag_multiple(self):
-        result = self.parser.parse(u'text #hashtag1 #hashtag2')
-        self.assertEqual(result.html, u'text <a href="https://twitter.com/search?q=%23hashtag1">#hashtag1</a> <a href="https://twitter.com/search?q=%23hashtag2">#hashtag2</a>')
-        self.assertEqual(result.tags, [u'hashtag1', u'hashtag2'])
+        result = self.parser.parse('text #hashtag1 #hashtag2')
+        self.assertEqual(result.html, 'text <a href="https://twitter.com/search?q=%23hashtag1">#hashtag1</a> <a href="https://twitter.com/search?q=%23hashtag2">#hashtag2</a>')
+        self.assertEqual(result.tags, ['hashtag1', 'hashtag2'])
 
     def test_not_hashtag_number(self):
-        result = self.parser.parse(u'text #1234')
-        self.assertEqual(result.html, u'text #1234')
+        result = self.parser.parse('text #1234')
+        self.assertEqual(result.html, 'text #1234')
         self.assertEqual(result.tags, [])
 
     def test_not_hashtag_text(self):
-        result = self.parser.parse(u'text#hashtag')
-        self.assertEqual(result.html, u'text#hashtag')
+        result = self.parser.parse('text#hashtag')
+        self.assertEqual(result.html, 'text#hashtag')
         self.assertEqual(result.tags, [])
 
     def test_hashtag_umlaut(self):
-        result = self.parser.parse(u'text #hash_tagüäö')
-        self.assertEqual(result.html, u'text <a href="https://twitter.com/search?q=%23hash_tag%C3%BC%C3%A4%C3%B6">#hash_tagüäö</a>')
-        self.assertEqual(result.tags, [u'hash_tag\xfc\xe4\xf6'])
+        result = self.parser.parse('text #hash_tagüäö')
+        self.assertEqual(result.html, 'text <a href="https://twitter.com/search?q=%23hash_tag%C3%BC%C3%A4%C3%B6">#hash_tagüäö</a>')
+        self.assertEqual(result.tags, ['hash_tag\xfc\xe4\xf6'])
 
     def test_hashtag_alpha(self):
-        result = self.parser.parse(u'text #hash0tag')
-        self.assertEqual(result.html, u'text <a href="https://twitter.com/search?q=%23hash0tag">#hash0tag</a>')
-        self.assertEqual(result.tags, [u'hash0tag'])
+        result = self.parser.parse('text #hash0tag')
+        self.assertEqual(result.html, 'text <a href="https://twitter.com/search?q=%23hash0tag">#hash0tag</a>')
+        self.assertEqual(result.tags, ['hash0tag'])
 
     def test_hashtag_under(self):
-        result = self.parser.parse(u'text #hash_tag')
-        self.assertEqual(result.html, u'text <a href="https://twitter.com/search?q=%23hash_tag">#hash_tag</a>')
-        self.assertEqual(result.tags, [u'hash_tag'])
+        result = self.parser.parse('text #hash_tag')
+        self.assertEqual(result.html, 'text <a href="https://twitter.com/search?q=%23hash_tag">#hash_tag</a>')
+        self.assertEqual(result.tags, ['hash_tag'])
 
     # Username tests -----------------------------------------------------------
     # --------------------------------------------------------------------------
     def test_not_username_preceded_letter(self):
-        result = self.parser.parse(u'meet@the beach')
-        self.assertEqual(result.html, u'meet@the beach')
+        result = self.parser.parse('meet@the beach')
+        self.assertEqual(result.html, 'meet@the beach')
         self.assertEqual(result.users, [])
 
     def test_username_preceded_punctuation(self):
-        result = self.parser.parse(u'.@username')
-        self.assertEqual(result.html, u'.<a href="https://twitter.com/username">@username</a>')
-        self.assertEqual(result.users, [u'username'])
+        result = self.parser.parse('.@username')
+        self.assertEqual(result.html, '.<a href="https://twitter.com/username">@username</a>')
+        self.assertEqual(result.users, ['username'])
 
     def test_username_preceded_japanese(self):
-        result = self.parser.parse(u'あ@username')
-        self.assertEqual(result.html, u'あ<a href="https://twitter.com/username">@username</a>')
-        self.assertEqual(result.users, [u'username'])
+        result = self.parser.parse('あ@username')
+        self.assertEqual(result.html, 'あ<a href="https://twitter.com/username">@username</a>')
+        self.assertEqual(result.users, ['username'])
 
     def test_username_followed_japanese(self):
-        result = self.parser.parse(u'@usernameの')
-        self.assertEqual(result.html, u'<a href="https://twitter.com/username">@username</a>の')
-        self.assertEqual(result.users, [u'username'])
+        result = self.parser.parse('@usernameの')
+        self.assertEqual(result.html, '<a href="https://twitter.com/username">@username</a>の')
+        self.assertEqual(result.users, ['username'])
 
     def test_username_surrounded_japanese(self):
-        result = self.parser.parse(u'あ@usernameの')
-        self.assertEqual(result.html, u'あ<a href="https://twitter.com/username">@username</a>の')
-        self.assertEqual(result.users, [u'username'])
+        result = self.parser.parse('あ@usernameの')
+        self.assertEqual(result.html, 'あ<a href="https://twitter.com/username">@username</a>の')
+        self.assertEqual(result.users, ['username'])
 
     def test_username_followed_punctuation(self):
-        result = self.parser.parse(u'@username&^$%^')
-        self.assertEqual(result.html, u'<a href="https://twitter.com/username">@username</a>&^$%^')
-        self.assertEqual(result.users, [u'username'])
+        result = self.parser.parse('@username&^$%^')
+        self.assertEqual(result.html, '<a href="https://twitter.com/username">@username</a>&^$%^')
+        self.assertEqual(result.users, ['username'])
 
     def test_not_username_spaced(self):
-        result = self.parser.parse(u'@ username')
-        self.assertEqual(result.html, u'@ username')
+        result = self.parser.parse('@ username')
+        self.assertEqual(result.html, '@ username')
         self.assertEqual(result.users, [])
 
     def test_username_beginning(self):
-        result = self.parser.parse(u'@username text')
-        self.assertEqual(result.html, u'<a href="https://twitter.com/username">@username</a> text')
-        self.assertEqual(result.users, [u'username'])
+        result = self.parser.parse('@username text')
+        self.assertEqual(result.html, '<a href="https://twitter.com/username">@username</a> text')
+        self.assertEqual(result.users, ['username'])
 
     def test_username_to_long(self):
-        result = self.parser.parse(u'@username9012345678901')
-        self.assertEqual(result.html, u'<a href="https://twitter.com/username901234567890">@username901234567890</a>1')
-        self.assertEqual(result.users, [u'username901234567890'])
+        result = self.parser.parse('@username9012345678901')
+        self.assertEqual(result.html, '<a href="https://twitter.com/username901234567890">@username901234567890</a>1')
+        self.assertEqual(result.users, ['username901234567890'])
 
     def test_username_full_at_sign(self):
-        result = self.parser.parse(u'＠username')
-        self.assertEqual(result.html, u'<a href="https://twitter.com/username">＠username</a>')
-        self.assertEqual(result.users, [u'username'])
+        result = self.parser.parse('＠username')
+        self.assertEqual(result.html, '<a href="https://twitter.com/username">＠username</a>')
+        self.assertEqual(result.users, ['username'])
 
     def test_username_trailing(self):
-        result = self.parser.parse(u'text @username')
-        self.assertEqual(result.html, u'text <a href="https://twitter.com/username">@username</a>')
-        self.assertEqual(result.users, [u'username'])
+        result = self.parser.parse('text @username')
+        self.assertEqual(result.html, 'text <a href="https://twitter.com/username">@username</a>')
+        self.assertEqual(result.users, ['username'])
 
     # Replies
     def test_username_reply_simple(self):
-        result = self.parser.parse(u'@username')
-        self.assertEqual(result.html, u'<a href="https://twitter.com/username">@username</a>')
-        self.assertEqual(result.users, [u'username'])
-        self.assertEqual(result.reply, u'username')
+        result = self.parser.parse('@username')
+        self.assertEqual(result.html, '<a href="https://twitter.com/username">@username</a>')
+        self.assertEqual(result.users, ['username'])
+        self.assertEqual(result.reply, 'username')
 
     def test_username_reply_whitespace(self):
-        result = self.parser.parse(u'   @username')
-        self.assertEqual(result.html, u'   <a href="https://twitter.com/username">@username</a>')
-        self.assertEqual(result.users, [u'username'])
-        self.assertEqual(result.reply, u'username')
+        result = self.parser.parse('   @username')
+        self.assertEqual(result.html, '   <a href="https://twitter.com/username">@username</a>')
+        self.assertEqual(result.users, ['username'])
+        self.assertEqual(result.reply, 'username')
 
     def test_username_reply_full(self):
-        result = self.parser.parse(u'　@username')
-        self.assertEqual(result.html, u'　<a href="https://twitter.com/username">@username</a>')
-        self.assertEqual(result.users, [u'username'])
-        self.assertEqual(result.reply, u'username')
+        result = self.parser.parse('　@username')
+        self.assertEqual(result.html, '　<a href="https://twitter.com/username">@username</a>')
+        self.assertEqual(result.users, ['username'])
+        self.assertEqual(result.reply, 'username')
 
     def test_username_non_reply(self):
-        result = self.parser.parse(u'test @username')
-        self.assertEqual(result.html, u'test <a href="https://twitter.com/username">@username</a>')
-        self.assertEqual(result.users, [u'username'])
+        result = self.parser.parse('test @username')
+        self.assertEqual(result.html, 'test <a href="https://twitter.com/username">@username</a>')
+        self.assertEqual(result.users, ['username'])
         self.assertEqual(result.reply, None)
 
     # List tests ---------------------------------------------------------------
     # --------------------------------------------------------------------------
     def test_list_preceeded(self):
-        result = self.parser.parse(u'text @username/list')
-        self.assertEqual(result.html, u'text <a href="https://twitter.com/username/list">@username/list</a>')
-        self.assertEqual(result.lists, [(u'username', u'list')])
+        result = self.parser.parse('text @username/list')
+        self.assertEqual(result.html, 'text <a href="https://twitter.com/username/list">@username/list</a>')
+        self.assertEqual(result.lists, [('username', 'list')])
 
     def test_list_beginning(self):
-        result = self.parser.parse(u'@username/list')
-        self.assertEqual(result.html, u'<a href="https://twitter.com/username/list">@username/list</a>')
-        self.assertEqual(result.lists, [(u'username', u'list')])
+        result = self.parser.parse('@username/list')
+        self.assertEqual(result.html, '<a href="https://twitter.com/username/list">@username/list</a>')
+        self.assertEqual(result.lists, [('username', 'list')])
 
     def test_list_preceeded_punctuation(self):
-        result = self.parser.parse(u'.@username/list')
-        self.assertEqual(result.html, u'.<a href="https://twitter.com/username/list">@username/list</a>')
-        self.assertEqual(result.lists, [(u'username', u'list')])
+        result = self.parser.parse('.@username/list')
+        self.assertEqual(result.html, '.<a href="https://twitter.com/username/list">@username/list</a>')
+        self.assertEqual(result.lists, [('username', 'list')])
 
     def test_list_followed_punctuation(self):
-        result = self.parser.parse(u'@username/list&^$%^')
-        self.assertEqual(result.html, u'<a href="https://twitter.com/username/list">@username/list</a>&^$%^')
-        self.assertEqual(result.lists, [(u'username', u'list')])
+        result = self.parser.parse('@username/list&^$%^')
+        self.assertEqual(result.html, '<a href="https://twitter.com/username/list">@username/list</a>&^$%^')
+        self.assertEqual(result.lists, [('username', 'list')])
 
     def test_list_not_slash_space(self):
-        result = self.parser.parse(u'@username/ list')
-        self.assertEqual(result.html, u'<a href="https://twitter.com/username">@username</a>/ list')
-        self.assertEqual(result.users, [u'username'])
+        result = self.parser.parse('@username/ list')
+        self.assertEqual(result.html, '<a href="https://twitter.com/username">@username</a>/ list')
+        self.assertEqual(result.users, ['username'])
         self.assertEqual(result.lists, [])
 
     def test_list_beginning2(self):
-        result = self.parser.parse(u'@username/list')
-        self.assertEqual(result.html, u'<a href="https://twitter.com/username/list">@username/list</a>')
-        self.assertEqual(result.lists, [(u'username', u'list')])
+        result = self.parser.parse('@username/list')
+        self.assertEqual(result.html, '<a href="https://twitter.com/username/list">@username/list</a>')
+        self.assertEqual(result.lists, [('username', 'list')])
 
     def test_list_not_empty_username(self):
-        result = self.parser.parse(u'text @/list')
-        self.assertEqual(result.html, u'text @/list')
+        result = self.parser.parse('text @/list')
+        self.assertEqual(result.html, 'text @/list')
         self.assertEqual(result.lists, [])
 
     def test_list_not_preceeded_letter(self):
-        result = self.parser.parse(u'meet@the/beach')
-        self.assertEqual(result.html, u'meet@the/beach')
+        result = self.parser.parse('meet@the/beach')
+        self.assertEqual(result.html, 'meet@the/beach')
         self.assertEqual(result.lists, [])
 
     def test_list_long_truncate(self):
-        result = self.parser.parse(u'@username/list5678901234567890123456789012345678901234567890123456789012345678901234567890A')
+        result = self.parser.parse('@username/list5678901234567890123456789012345678901234567890123456789012345678901234567890A')
         self.assertEqual(
-            result.html, u'<a href="https://twitter.com/username/list5678901234567890123456789012345678901234567890123456789012345678901234567890">@username/list5678901234567890123456789012345678901234567890123456789012345678901234567890</a>A')
-        self.assertEqual(result.lists, [(u'username', u'list5678901234567890123456789012345678901234567890123456789012345678901234567890')])
+            result.html, '<a href="https://twitter.com/username/list5678901234567890123456789012345678901234567890123456789012345678901234567890">@username/list5678901234567890123456789012345678901234567890123456789012345678901234567890</a>A')
+        self.assertEqual(result.lists, [('username', 'list5678901234567890123456789012345678901234567890123456789012345678901234567890')])
 
     def test_list_with_dash(self):
-        result = self.parser.parse(u'text @username/list-foo')
-        self.assertEqual(result.html, u'text <a href="https://twitter.com/username/list-foo">@username/list-foo</a>')
-        self.assertEqual(result.lists, [(u'username', u'list-foo')])
+        result = self.parser.parse('text @username/list-foo')
+        self.assertEqual(result.html, 'text <a href="https://twitter.com/username/list-foo">@username/list-foo</a>')
+        self.assertEqual(result.lists, [('username', 'list-foo')])
 
 
 class TWPTestsWithSpans(unittest.TestCase):
@@ -572,33 +573,33 @@ class TWPTestsWithSpans(unittest.TestCase):
 
     def test_spans_in_tweets(self):
         """Test some coca-cola tweets taken from twitter with spans"""
-        result = self.parser.parse(u'Coca-Cola Hits 50 Million Facebook Likes http://bit.ly/QlKOc7')
+        result = self.parser.parse('Coca-Cola Hits 50 Million Facebook Likes http://bit.ly/QlKOc7')
         self.assertEqual(result.urls, [('http://bit.ly/QlKOc7', (41, 61))])
 
-        result = self.parser.parse(u' #ABillionReasonsToBelieveInAfrica ARISE MAG.FASHION WEEK NY! Tsemaye B,Maki Oh,Tiffany Amber, Ozwald.Showin NY reasons2beliv @CocaCola_NG', html=False)
+        result = self.parser.parse(' #ABillionReasonsToBelieveInAfrica ARISE MAG.FASHION WEEK NY! Tsemaye B,Maki Oh,Tiffany Amber, Ozwald.Showin NY reasons2beliv @CocaCola_NG', html=False)
         self.assertEqual(result.urls, [])
-        self.assertEqual(result.tags, [(u'ABillionReasonsToBelieveInAfrica', (1, 34))])
-        self.assertEqual(result.users, [(u'CocaCola_NG', (126, 138))])
+        self.assertEqual(result.tags, [('ABillionReasonsToBelieveInAfrica', (1, 34))])
+        self.assertEqual(result.users, [('CocaCola_NG', (126, 138))])
 
-        result = self.parser.parse(u'Follow @CokeZero & Retweet for a chance to win @EASPORTS @EANCAAFootball 13 #GameOn #ad Rules: http://bit.ly/EANCAA', html=False)
-        self.assertEqual(result.urls, [(u'http://bit.ly/EANCAA', (95, 115))])
-        self.assertEqual(result.users, [(u'CokeZero', (7, 16)), (u'EASPORTS', (47, 56)), (u'EANCAAFootball', (57, 72))])
-        self.assertEqual(result.tags, [(u'GameOn', (76, 83)), (u'ad', (84, 87))])
+        result = self.parser.parse('Follow @CokeZero & Retweet for a chance to win @EASPORTS @EANCAAFootball 13 #GameOn #ad Rules: http://bit.ly/EANCAA', html=False)
+        self.assertEqual(result.urls, [('http://bit.ly/EANCAA', (95, 115))])
+        self.assertEqual(result.users, [('CokeZero', (7, 16)), ('EASPORTS', (47, 56)), ('EANCAAFootball', (57, 72))])
+        self.assertEqual(result.tags, [('GameOn', (76, 83)), ('ad', (84, 87))])
 
     def test_users_in_tweets(self):
-        result = self.parser.parse(u'Follow @CokeZero & Retweet for a chance to win @EASPORTS @EANCAAFootball 13 #GameOn #ad Rules: http://bit.ly/EANCAA @someone', html=False)
-        self.assertEqual(result.users, [(u'CokeZero', (7, 16)), (u'EASPORTS', (47, 56)), (u'EANCAAFootball', (57, 72)), (u'someone', (116, 124))])
+        result = self.parser.parse('Follow @CokeZero & Retweet for a chance to win @EASPORTS @EANCAAFootball 13 #GameOn #ad Rules: http://bit.ly/EANCAA @someone', html=False)
+        self.assertEqual(result.users, [('CokeZero', (7, 16)), ('EASPORTS', (47, 56)), ('EANCAAFootball', (57, 72)), ('someone', (116, 124))])
 
     def test_edge_cases(self):
         """Some edge cases that upset the original version of ttp"""
-        result = self.parser.parse(u' @user', html=False)
-        self.assertEqual(result.users, [(u'user', (1, 6))])
+        result = self.parser.parse(' @user', html=False)
+        self.assertEqual(result.users, [('user', (1, 6))])
 
-        result = self.parser.parse(u' #hash ', html=False)
-        self.assertEqual(result.tags, [(u'hash', (1, 6))])
+        result = self.parser.parse(' #hash ', html=False)
+        self.assertEqual(result.tags, [('hash', (1, 6))])
 
-        result = self.parser.parse(u' http://some.com ', html=False)
-        self.assertEqual(result.urls, [(u'http://some.com', (1, 16))])
+        result = self.parser.parse(' http://some.com ', html=False)
+        self.assertEqual(result.urls, [('http://some.com', (1, 16))])
 
 
 # Test it!

--- a/ttp/ttp.py
+++ b/ttp/ttp.py
@@ -23,7 +23,10 @@
 from __future__ import unicode_literals
 
 import re
-import urllib
+try:
+    from urllib.parse import quote  # Python3
+except ImportError:
+    from urllib import quote
 
 __version__ = "1.0.1.0"
 
@@ -268,7 +271,7 @@ class Parser(object):
     def format_tag(self, tag, text):
         '''Return formatted HTML for a hashtag.'''
         return '<a href="https://twitter.com/search?q=%s">%s%s</a>' \
-            % (urllib.quote(('#' + text).encode('utf-8')), tag, text)
+            % (quote(('#' + text).encode('utf-8')), tag, text)
 
     def format_username(self, at_char, user):
         '''Return formatted HTML for a username.'''

--- a/ttp/ttp.py
+++ b/ttp/ttp.py
@@ -234,7 +234,7 @@ class Parser(object):
 
         # Fix problems with the regex capturing stuff infront of the #
         tag = None
-        for i in u'#\uff03':
+        for i in '#\uff03':
             pos = mat.rfind(i)
             if pos != -1:
                 tag = i

--- a/ttp/ttp.py
+++ b/ttp/ttp.py
@@ -20,6 +20,8 @@
 
 # Tweet Parser and Formatter ---------------------------------------------------
 # ------------------------------------------------------------------------------
+from __future__ import unicode_literals
+
 import re
 import urllib
 
@@ -27,31 +29,31 @@ __version__ = "1.0.1.0"
 
 # Some of this code has been translated from the twitter-text-java library:
 # <http://github.com/mzsanford/twitter-text-java>
-AT_SIGNS = ur'[@\uff20]'
-UTF_CHARS = ur'a-z0-9_\u00c0-\u00d6\u00d8-\u00f6\u00f8-\u00ff'
-SPACES = ur'[\u0020\u00A0\u1680\u180E\u2002-\u202F\u205F\u2060\u3000]'
+AT_SIGNS = r'[@\uff20]'
+UTF_CHARS = r'a-z0-9_\u00c0-\u00d6\u00d8-\u00f6\u00f8-\u00ff'
+SPACES = r'[\u0020\u00A0\u1680\u180E\u2002-\u202F\u205F\u2060\u3000]'
 
 # Lists
-LIST_PRE_CHARS = ur'([^a-z0-9_]|^)'
-LIST_END_CHARS = ur'([a-z0-9_]{1,20})(/[a-z][a-z0-9\x80-\xFF-]{0,79})?'
+LIST_PRE_CHARS = r'([^a-z0-9_]|^)'
+LIST_END_CHARS = r'([a-z0-9_]{1,20})(/[a-z][a-z0-9\x80-\xFF-]{0,79})?'
 LIST_REGEX = re.compile(LIST_PRE_CHARS + '(' + AT_SIGNS + '+)' + LIST_END_CHARS,
                         re.IGNORECASE)
 
 # Users
-USERNAME_REGEX = re.compile(ur'\B' + AT_SIGNS + LIST_END_CHARS, re.IGNORECASE)
-REPLY_REGEX = re.compile(ur'^(?:' + SPACES + ur')*' + AT_SIGNS
-                         + ur'([a-z0-9_]{1,20}).*', re.IGNORECASE)
+USERNAME_REGEX = re.compile(r'\B' + AT_SIGNS + LIST_END_CHARS, re.IGNORECASE)
+REPLY_REGEX = re.compile(r'^(?:' + SPACES + r')*' + AT_SIGNS
+                         + r'([a-z0-9_]{1,20}).*', re.IGNORECASE)
 
 # Hashtags
-HASHTAG_EXP = ur'(^|[^0-9A-Z&/]+)(#|\uff03)([0-9A-Z_]*[A-Z_]+[%s]*)' % UTF_CHARS
+HASHTAG_EXP = r'(^|[^0-9A-Z&/]+)(#|\uff03)([0-9A-Z_]*[A-Z_]+[%s]*)' % UTF_CHARS
 HASHTAG_REGEX = re.compile(HASHTAG_EXP, re.IGNORECASE)
 
 
 # URLs
-PRE_CHARS = ur'(?:[^/"\':!=]|^|\:)'
-DOMAIN_CHARS = ur'([\.-]|[^\s_\!\.\/])+\.[a-z]{2,}(?::[0-9]+)?'
-PATH_CHARS = ur'(?:[\.,]?[%s!\*\'\(\);:=\+\$/%s#\[\]\-_,~@])' % (UTF_CHARS, '%')
-QUERY_CHARS = ur'[a-z0-9!\*\'\(\);:&=\+\$/%#\[\]\-_\.,~]'
+PRE_CHARS = r'(?:[^/"\':!=]|^|\:)'
+DOMAIN_CHARS = r'([\.-]|[^\s_\!\.\/])+\.[a-z]{2,}(?::[0-9]+)?'
+PATH_CHARS = r'(?:[\.,]?[%s!\*\'\(\);:=\+\$/%s#\[\]\-_,~@])' % (UTF_CHARS, '%')
+QUERY_CHARS = r'[a-z0-9!\*\'\(\);:&=\+\$/%#\[\]\-_\.,~]'
 
 # Valid end-of-path chracters (so /foo. does not gobble the period).
 # 1. Allow ) for Wikipedia URLs.
@@ -266,7 +268,7 @@ class Parser(object):
     def format_tag(self, tag, text):
         '''Return formatted HTML for a hashtag.'''
         return '<a href="https://twitter.com/search?q=%s">%s%s</a>' \
-            % (urllib.quote('#' + text.encode('utf-8')), tag, text)
+            % (urllib.quote(('#' + text).encode('utf-8')), tag, text)
 
     def format_username(self, at_char, user):
         '''Return formatted HTML for a username.'''

--- a/ttp/utils.py
+++ b/ttp/utils.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """Unwind short-links e.g. bit.ly, t.co etc to their canonical links"""
+from __future__ import unicode_literals
 import requests
 
 
@@ -24,5 +25,5 @@ def follow_shortlinks(shortlinks):
 
 
 if __name__ == "__main__":
-    shortlinks = ['http://t.co/8o0z9BbEMu', u'http://bbc.in/16dClPF']
+    shortlinks = ['http://t.co/8o0z9BbEMu', 'http://bbc.in/16dClPF']
     print follow_shortlinks(shortlinks)


### PR DESCRIPTION
All tests are passing on Python 2.7

On Python3.3, 3.4, two tests are still failing:
```
======================================================================
FAIL: test_username_preceded_japanese (__main__.TWPTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "ttp/tests.py", line 445, in test_username_preceded_japanese
    self.assertEqual(result.html, 'あ<a href="https://twitter.com/username">@username</a>')
AssertionError: 'あ@username' != 'あ<a href="https://twitter.com/username">@username</a>'
- あ@username
+ あ<a href="https://twitter.com/username">@username</a>


======================================================================
FAIL: test_username_surrounded_japanese (__main__.TWPTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "ttp/tests.py", line 455, in test_username_surrounded_japanese
    self.assertEqual(result.html, 'あ<a href="https://twitter.com/username">@username</a>の')
AssertionError: 'あ@usernameの' != 'あ<a href="https://twitter.com/username">@username</a>の'
- あ@usernameの
+ あ<a href="https://twitter.com/username">@username</a>の


----------------------------------------------------------------------
Ran 100 tests in 0.035s

FAILED (failures=2)
```
Trying to figure out how to fix those.

On 3.2 more tests are failing, but I'm not sure if 3.2 support is critical or not.

Ref #4 